### PR TITLE
feature: fixes fallback version of latest release

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -42,4 +42,4 @@ export const downloadOptions = [
 ];
 
 export const latestRelease =
-  "https://github.com/CityOfZion/neon-wallet/releases/tag/0.1.1";
+  "https://github.com/CityOfZion/neon-wallet/releases/tag/2.0.0";


### PR DESCRIPTION
This PR updates the fallback version (in the event of the github releases API being down) to the latest and greatest - 2.0.0